### PR TITLE
patch for lines without event_type

### DIFF
--- a/modules/processing/suricata.py
+++ b/modules/processing/suricata.py
@@ -230,98 +230,99 @@ class Suricata(Processing):
                     log.warning("Suricata: Failed to parse line as json" % (line))
                     continue
 
-                if parsed["event_type"] == "alert":
-                    if (parsed["alert"]["signature_id"] not in sid_blacklist
-                        and not parsed["alert"]["signature"].startswith(
-                            "SURICATA STREAM")):
-                        alog = dict()
-                        if parsed["alert"]["gid"] == '':
-                            alog["gid"] = "None"
-                        else:
-                            alog["gid"] = parsed["alert"]["gid"]
-                        if parsed["alert"]["rev"] == '':
-                            alog["rev"] = "None"
-                        else:
-                            alog["rev"] = parsed["alert"]["rev"]
-                        if parsed["alert"]["severity"] == '':
-                            alog["severity"] = "None"
-                        else:
-                            alog["severity"] = parsed["alert"]["severity"]
-                        alog["sid"] = parsed["alert"]["signature_id"]
+                if 'event_type' in parsed:
+                    if parsed["event_type"] == "alert":
+                        if (parsed["alert"]["signature_id"] not in sid_blacklist
+                            and not parsed["alert"]["signature"].startswith(
+                                "SURICATA STREAM")):
+                            alog = dict()
+                            if parsed["alert"]["gid"] == '':
+                                alog["gid"] = "None"
+                            else:
+                                alog["gid"] = parsed["alert"]["gid"]
+                            if parsed["alert"]["rev"] == '':
+                                alog["rev"] = "None"
+                            else:
+                                alog["rev"] = parsed["alert"]["rev"]
+                            if parsed["alert"]["severity"] == '':
+                                alog["severity"] = "None"
+                            else:
+                                alog["severity"] = parsed["alert"]["severity"]
+                            alog["sid"] = parsed["alert"]["signature_id"]
+                            try:
+                                alog["srcport"] = parsed["src_port"]
+                            except:
+                                alog["srcport"] = "None"
+                            alog["srcip"] = parsed["src_ip"]
+                            try:
+                                alog["dstport"] = parsed["dest_port"]
+                            except:
+                                alog["dstport"] = "None"
+                            alog["dstip"] = parsed["dest_ip"]
+                            alog["protocol"] = parsed["proto"]
+                            alog["timestamp"] = parsed["timestamp"].replace("T", " ")
+                            if parsed["alert"]["category"] == '':
+                                alog["category"] = "None"
+                            else:
+                                alog["category"] = parsed["alert"]["category"]
+                            alog["signature"] = parsed["alert"]["signature"]
+                            suricata["alerts"].append(alog)
+
+                    elif parsed["event_type"] == "http":
+                        hlog = dict()
+                        hlog["srcport"] = parsed["src_port"]
+                        hlog["srcip"] = parsed["src_ip"]
+                        hlog["dstport"] = parsed["dest_port"]
+                        hlog["dstip"] = parsed["dest_ip"]
+                        hlog["timestamp"] = parsed["timestamp"].replace("T", " ")
                         try:
-                            alog["srcport"] = parsed["src_port"]
+                            hlog["uri"] = parsed["http"]["url"]
                         except:
-                            alog["srcport"] = "None"
-                        alog["srcip"] = parsed["src_ip"]
+                            hlog["uri"] = "None"
+                        hlog["length"] = parsed["http"]["length"]
                         try:
-                            alog["dstport"] = parsed["dest_port"]
+                            hlog["hostname"] = parsed["http"]["hostname"]
                         except:
-                            alog["dstport"] = "None"
-                        alog["dstip"] = parsed["dest_ip"]
-                        alog["protocol"] = parsed["proto"]
-                        alog["timestamp"] = parsed["timestamp"].replace("T", " ")
-                        if parsed["alert"]["category"] == '':
-                            alog["category"] = "None"
-                        else:
-                            alog["category"] = parsed["alert"]["category"]
-                        alog["signature"] = parsed["alert"]["signature"]
-                        suricata["alerts"].append(alog)
+                            hlog["hostname"] = "None"
+                        try:
+                            hlog["status"] = str(parsed["http"]["status"])
+                        except:
+                            hlog["status"] = "None"
+                        try:
+                           hlog["method"] = parsed["http"]["http_method"]
+                        except:
+                            hlog["method"] = "None"
+                        try:
+                           hlog["contenttype"] = parsed["http"]["http_content_type"]
+                        except:
+                            hlog["contenttype"] = "None"
+                        try:
+                            hlog["ua"] = parsed["http"]["http_user_agent"]
+                        except:
+                            hlog["ua"] = "None"
+                        try:
+                            hlog["referrer"] = parsed["http"]["http_refer"]
+                        except:
+                            hlog["referrer"] = "None"
+                        suricata["http"].append(hlog)
 
-                elif parsed["event_type"] == "http":
-                    hlog = dict()
-                    hlog["srcport"] = parsed["src_port"]
-                    hlog["srcip"] = parsed["src_ip"]
-                    hlog["dstport"] = parsed["dest_port"]
-                    hlog["dstip"] = parsed["dest_ip"]
-                    hlog["timestamp"] = parsed["timestamp"].replace("T", " ")
-                    try:
-                        hlog["uri"] = parsed["http"]["url"]
-                    except:
-                        hlog["uri"] = "None"
-                    hlog["length"] = parsed["http"]["length"]
-                    try:
-                        hlog["hostname"] = parsed["http"]["hostname"]
-                    except:
-                        hlog["hostname"] = "None"
-                    try:
-                        hlog["status"] = str(parsed["http"]["status"])
-                    except:
-                        hlog["status"] = "None"
-                    try:
-                       hlog["method"] = parsed["http"]["http_method"]
-                    except:
-                        hlog["method"] = "None"
-                    try:
-                       hlog["contenttype"] = parsed["http"]["http_content_type"]
-                    except:
-                        hlog["contenttype"] = "None"
-                    try:
-                        hlog["ua"] = parsed["http"]["http_user_agent"]
-                    except:
-                        hlog["ua"] = "None"
-                    try:
-                        hlog["referrer"] = parsed["http"]["http_refer"]
-                    except:
-                        hlog["referrer"] = "None"
-                    suricata["http"].append(hlog)
+                    elif parsed["event_type"] == "tls":
+                        tlog = dict()
+                        tlog["srcport"] = parsed["src_port"]
+                        tlog["srcip"] = parsed["src_ip"]
+                        tlog["dstport"] = parsed["dest_port"]
+                        tlog["dstip"] = parsed["dest_ip"]
+                        tlog["timestamp"] = parsed["timestamp"].replace("T", " ")
+                        tlog["fingerprint"] = parsed["tls"]["fingerprint"]
+                        tlog["issuer"] = parsed["tls"]["issuerdn"]
+                        tlog["version"] = parsed["tls"]["version"]
+                        tlog["subject"] = parsed["tls"]["subject"]
+                        suricata["tls"].append(tlog)
 
-                elif parsed["event_type"] == "tls":
-                    tlog = dict()
-                    tlog["srcport"] = parsed["src_port"]
-                    tlog["srcip"] = parsed["src_ip"]
-                    tlog["dstport"] = parsed["dest_port"]
-                    tlog["dstip"] = parsed["dest_ip"]
-                    tlog["timestamp"] = parsed["timestamp"].replace("T", " ")
-                    tlog["fingerprint"] = parsed["tls"]["fingerprint"]
-                    tlog["issuer"] = parsed["tls"]["issuerdn"]
-                    tlog["version"] = parsed["tls"]["version"]
-                    tlog["subject"] = parsed["tls"]["subject"]
-                    suricata["tls"].append(tlog)
-
-                elif parsed["event_type"] == "ssh":
-                    suricata["ssh"].append(parsed)
-                elif parsed["event_type"] == "dns":
-                    suricata["dns"].append(parsed)
+                    elif parsed["event_type"] == "ssh":
+                        suricata["ssh"].append(parsed)
+                    elif parsed["event_type"] == "dns":
+                        suricata["dns"].append(parsed)
 
         if os.path.exists(SURICATA_FILE_LOG_FULL_PATH):
             suricata["file_log_full_path"] = SURICATA_FILE_LOG_FULL_PATH


### PR DESCRIPTION
sids like 2100527 (GPL SCAN same SRC/DST) cause suricata.py to crash, the json like does not contain event_type

Crash:
module "Suricata":
Traceback (most recent call last):
  File "/opt/cuckoo/lib/cuckoo/core/plugins.py", line 197, in process
    data = current.run()
  File "/opt/cuckoo/modules/processing/suricata.py", line 233, in run
    if parsed["event_type"] == "alert":
KeyError: 'event_type'

eve.json line:

{"timestamp":"2016-11-13T09:05:00.117653-0500","alert":{"action":"allowed","gid":1,"signature_id":2100527,"rev":9,"signature":"GPL SCAN same SRC\/DST","category":"Potentially Bad Traffic","severity":2}}
